### PR TITLE
Fix pkg_resources import error and restore backwards compatibility

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ package_dir =
 packages = find:
 python_requires = >=3.10
 install_requires =
+    httpx
     plumbum
     pyperclip
     tqdm

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = agor
-version = 0.1.1
+version = 0.1.2
 author = Jeremiah K.
 author_email = jeremiahk@gmx.com
 description = AgentOrchestrator - Multi-Agent Development Coordination Platform

--- a/src/agor/__init__.py
+++ b/src/agor/__init__.py
@@ -22,7 +22,7 @@ else:
         __version__ = version("agor")
     except PackageNotFoundError:
         # If all else fails, use hardcoded version
-        __version__ = "0.1.1"
+        __version__ = "0.1.2"
 
 __author__ = "Jeremiah K."
 __email__ = "jeremiahk@gmx.com"

--- a/src/agor/__init__.py
+++ b/src/agor/__init__.py
@@ -7,16 +7,20 @@ specialized prompts for coordinated AI development workflows.
 """
 
 import os
-import pkg_resources
+try:
+    from importlib.metadata import version, PackageNotFoundError
+except ImportError:
+    # Fallback for Python < 3.8
+    from importlib_metadata import version, PackageNotFoundError
 
 # First try to get version from environment variable (GitHub tag)
 if "GITHUB_REF_NAME" in os.environ:
     __version__ = os.environ.get("GITHUB_REF_NAME")
 else:
-    # Fall back to setup.cfg metadata using pkg_resources (compatible with PyInstaller)
+    # Fall back to package metadata using importlib.metadata (modern replacement for pkg_resources)
     try:
-        __version__ = pkg_resources.get_distribution("agor").version
-    except pkg_resources.DistributionNotFound:
+        __version__ = version("agor")
+    except PackageNotFoundError:
         # If all else fails, use hardcoded version
         __version__ = "0.1.1"
 

--- a/src/agor/main.py
+++ b/src/agor/main.py
@@ -151,6 +151,12 @@ def bundle(
         "-m",
         help="Bundle only main/master branch",
     ),
+    all_branches: bool = typer.Option(
+        False,
+        "--all-branches",
+        "-a",
+        help="[DEPRECATED] Bundle all branches (this is now the default behavior)",
+    ),
     branches: list[str] = branches_option,
     interactive: bool = typer.Option(
         True, "--no-interactive", help="don't ask questions (batch) mode"
@@ -165,6 +171,12 @@ def bundle(
     Use -m/--main-only to bundle only main/master branch.
     Use -b/--branches to bundle main/master plus specified additional branches.
     """
+    # Handle deprecated -a/--all-branches flag
+    if all_branches:
+        print("⚠️  WARNING: The -a/--all-branches flag is deprecated.")
+        print("   All branches are now bundled by default. You can remove this flag.")
+        print()
+
     # clone_url = get_clone_url(src_repo) -- Assigned to but never used
     repo_name = get_clone_url(src_repo).split("/")[-1]
 

--- a/src/agor/main.py
+++ b/src/agor/main.py
@@ -155,7 +155,7 @@ def bundle(
         False,
         "--all-branches",
         "-a",
-        help="[DEPRECATED] Bundle all branches (this is now the default behavior)",
+        hidden=True,
     ),
     branches: list[str] = branches_option,
     interactive: bool = typer.Option(
@@ -171,12 +171,6 @@ def bundle(
     Use -m/--main-only to bundle only main/master branch.
     Use -b/--branches to bundle main/master plus specified additional branches.
     """
-    # Handle deprecated -a/--all-branches flag
-    if all_branches:
-        print("⚠️  WARNING: The -a/--all-branches flag is deprecated.")
-        print("   All branches are now bundled by default. You can remove this flag.")
-        print()
-
     # clone_url = get_clone_url(src_repo) -- Assigned to but never used
     repo_name = get_clone_url(src_repo).split("/")[-1]
 


### PR DESCRIPTION
## Problem
The agor package was failing to run with the error:
```
ModuleNotFoundError: No module named 'pkg_resources'
```

This occurs because `pkg_resources` is deprecated and not available in modern Python environments.

## Solution

### 1. Fixed pkg_resources Import Error
- Replaced deprecated `pkg_resources` with modern `importlib.metadata`
- Added fallback import for Python < 3.8 compatibility (though package requires >=3.10)
- Updated version detection logic to use `version("agor")` instead of `pkg_resources.get_distribution("agor").version`
- Updated exception handling to catch `PackageNotFoundError` instead of `pkg_resources.DistributionNotFound`

### 2. Added Missing Dependencies
- Added `httpx` to `install_requires` in setup.cfg (was missing but used in src/agor/utils.py)

### 3. Restored Backwards Compatibility
- Re-added `-a/--all-branches` flag for backwards compatibility
- Flag is hidden from help output but still works silently
- No deprecation warnings - works exactly as before
- Default behavior unchanged: bundles all branches

### 4. Version Bump
- Bumped version to 0.1.2 in both setup.cfg and fallback version

## Testing
- Verified that the package can be imported without errors
- Confirmed that version detection still works correctly
- Tested that `-a` flag works but is hidden from help
- Confirmed all branches are bundled by default

## Changes Summary
- ✅ Fixed `ModuleNotFoundError: No module named 'pkg_resources'`
- ✅ Added missing `httpx` dependency
- ✅ Restored `-a` flag backwards compatibility
- ✅ Bumped version to 0.1.2
- ✅ Maintained all existing functionality

Fixes the issue where `agor --version` and other commands fail due to missing pkg_resources module.