### PR TITLE
🔧 📚 Fix agent dependency installation confusion

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,10 @@
+# AGOR Tool Dependencies
+# These are required for AGOR's internal tools to function properly.
+#
+# FOR AGENTS: Install these with `pip install -r requirements.txt`
+# DO NOT install AGOR itself with `pip install .` or `pip install -e .`
+# You are working WITH the AGOR codebase, not installing it as a package.
+
 fastapi
 httpx
 plumbum

--- a/src/agor/tools/AGOR_INSTRUCTIONS.md
+++ b/src/agor/tools/AGOR_INSTRUCTIONS.md
@@ -35,6 +35,36 @@ As an AGOR agent, you'll interact with the system and the user in several ways. 
 
 After confirming your role, please perform these initial setup steps.
 
+### 1.0. Dependency Installation (Standalone Mode Only)
+
+**CRITICAL FOR STANDALONE MODE AGENTS**: If you encounter import errors for AGOR tools (e.g., `ModuleNotFoundError: No module named 'platformdirs'`), you need to install AGOR's tool dependencies.
+
+**⚠️ IMPORTANT DISTINCTION**:
+- **DO install tool dependencies**: `pip install -r requirements.txt`
+- **DO NOT install AGOR itself**: Never run `pip install .` or `pip install -e .`
+
+**Why this matters**:
+- AGOR's tools require certain Python packages (platformdirs, pydantic, etc.)
+- But you're working WITH the AGOR codebase, not installing it as a package
+- Installing AGOR as a package can cause conflicts and is unnecessary
+
+**Correct approach for dependency issues**:
+```bash
+# ✅ CORRECT: Install tool dependencies
+pip install -r requirements.txt
+
+# ❌ WRONG: Do not install AGOR itself
+# pip install .
+# pip install -e .
+```
+
+**When to do this**:
+- Only if you get import errors when trying to use AGOR tools
+- Only in standalone mode (bundle mode includes dependencies)
+- Only once per environment
+
+**After installing dependencies**, continue with the setup steps below.
+
 ### 1.1. Robust Repository Detection
 
 Execute this sequence until a valid git repository is found:

--- a/src/agor/tools/STANDALONE_INITIALIZATION.md
+++ b/src/agor/tools/STANDALONE_INITIALIZATION.md
@@ -18,6 +18,20 @@ You should have already selected your role from README_ai.md:
 
 ### Essential Setup (All Roles)
 
+**Dependency Installation (If Needed)**:
+If you encounter import errors when using AGOR tools (e.g., `ModuleNotFoundError: No module named 'platformdirs'`):
+
+```bash
+# ✅ CORRECT: Install tool dependencies
+pip install -r requirements.txt
+
+# ❌ WRONG: Do not install AGOR itself
+# pip install .
+# pip install -e .
+```
+
+**Important**: You are working WITH the AGOR codebase, not installing it as a package.
+
 1. **Verify AGOR tools access**:
 
    ```bash


### PR DESCRIPTION
- Add clear documentation in AGOR_INSTRUCTIONS.md about dependency vs package installation
- Clarify in requirements.txt that these are tool dependencies, not for installing AGOR
- Update STANDALONE_INITIALIZATION.md with dependency installation guidance
- Prevent agents from getting stuck trying to pip install AGOR itself

Fixes common issue where agents try pip install . or pip install -e . instead of just pip install -r requirements.txt for tool dependencies.

Timestamp: 2025-05-28 22:42 UTC